### PR TITLE
added tag descriptions to projections

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -274,6 +274,7 @@ get
 		{
 			_id: "ObjectId",
 			abbrev: "string",
+			description: "string",
 			name: "string"
 		}
 	]	
@@ -288,6 +289,7 @@ post
 
 {
 	abbrev: "string",
+	description: "string",
 	name: "string"
 }
 ------------------------------------------------------------------------------------------------------------------
@@ -301,6 +303,7 @@ patch
 {
 	abbrev: "string",
 	name: "string",
+	description: "string",
 	active: true
 }
 ------------------------------------------------------------------------------------------------------------------

--- a/routes/tags.js
+++ b/routes/tags.js
@@ -39,7 +39,7 @@ function getTags(tagIds, projection, callback){
 router.get("/", checkAuth(function(req, res, auth){
 	auth(true);
 }),function(req, res, next){
-	var tagProjection = {abbrev: 1, name: 1}
+	var tagProjection = {abbrev: 1, name: 1, description: 1}
 	var query = {active: true};
 
 	var body = req.query;
@@ -59,7 +59,7 @@ router.post("/", checkAuth(function(req, res, auth){
 }), function(req, res, next){
 	var body = req.body;
 	var errors = {};
-	utils.checkIn(body, ["name", "abbrev"], function(elem, res){
+	utils.checkIn(body, ["name", "abbrev", "description"], function(elem, res){
 		if(!res){
 			errors[elem] = "Required";
 		}
@@ -69,6 +69,7 @@ router.post("/", checkAuth(function(req, res, auth){
 		var data = {
 			name: String(body.name),
 			abbrev: String(body.abbrev).toUpperCase(),
+			description: String(body.description),
 			active: true
 		};
 		data = mongoSanitize.sanitize(data);
@@ -109,6 +110,10 @@ router.patch("/:tagId", checkAuth(function(req, res, auth){
 		data.abbrev = String(body.abbrev).toUpperCase();
 	}
 
+	if("description" in body){
+		data.description= String(body.description);
+	}
+	
 	if("active" in body){
 		var active = utils.toBool(body.active);
 		if(active != null){


### PR DESCRIPTION
Brief PR to mirror more substantial front-end changes:
- event tags on mongodb added back, new field includes tag descriptions rather than a hard-coded array on the frontend
- routes/tags.js reflects this change in its projections and additional type-checking for the property

future refactors should look into adding a property for tag categories (i.e. service, fellowship, leadership, miscellaneous) to allow the portal to be more secretary-operated - so DBoard may add future tags without messing up their current order. this was hard-coded in a previous version, but commented out on the frontend.