### PR TITLE
updating mongo-express-sanitize to 2.2.0 and removing temp fixes for known bug 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -475,9 +475,9 @@
       }
     },
     "express-mongo-sanitize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.1.0.tgz",
-      "integrity": "sha512-ELGeH/Tx+kJGn3klCzSmOewfN1ezJQrkqzq83dl/K3xhd5PUbvLtiD5CiuYRmQfoZPL4rUEVjANf/YjE2BpTWQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
+      "integrity": "sha512-PZBs5nwhD6ek9ZuP+W2xmpvcrHwXZxD5GdieX2dsjPbAbH4azOkrHbycBud2QRU+YQF1CT+pki/lZGedHgo/dQ=="
     },
     "express-session": {
       "version": "1.17.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cors": "^2.8.5",
     "debug": "^4.3.1",
     "express": "^4.17.1",
-    "express-mongo-sanitize": "^2.1.0",
+    "express-mongo-sanitize": "^2.2.0",
     "express-session": "^1.17.2",
     "http-errors": "^1.8.0",
     "jsonwebtoken": "^8.5.1",

--- a/routes/signin.js
+++ b/routes/signin.js
@@ -24,7 +24,7 @@ router.post('/', function(req, res, next){
 		return;
 	}
 
-	var query = {email: {$regex: "^" + String(mongoSanitize.sanitize(body['email'], {dryRun : false})) + "$", $options: "i"}};
+	var query = {email: {$regex: "^" + String(mongoSanitize.sanitize(body['email'])) + "$", $options: "i"}};
 	var projection = {name: 1, club_id: 1, division_id: 1, access: 1};
 
 	app.db.collection("members").findOne(query, projection, function(err, member){


### PR DESCRIPTION
Fixes known issue with express-mongo-sanitize where passing in an undefined object to `mongoSanitize.sanitize()` will return undefined `dryRun` error
- previous fix in [this commit](https://github.com/CNHCircleK/Online-MRF/commit/be1937aa864ca22ad3ecdaa9c0391389b1ec2924?fbclid=IwAR3aSmMAk_kVYxq-jUjENci_H-KHu7JCARh992A-QESGcY0SxCBEEH0zHeQ) has been removed
- mongo-express sanitize: 2.1.0 -> 2.2.0

**recommended: move updating all dependencies to be higher priority**